### PR TITLE
Add corp-sec-desk one-page site (Vite + three.js + GSAP)

### DIFF
--- a/corp-sec-desk/.gitignore
+++ b/corp-sec-desk/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/corp-sec-desk/PLACEHOLDERS.md
+++ b/corp-sec-desk/PLACEHOLDERS.md
@@ -1,0 +1,17 @@
+# Placeholders to fill before deploy
+
+Every bracketed value in the site that must be replaced with a real value.
+Search the codebase for `[` to confirm none remain before going live.
+
+| Placeholder | Where it appears | Replace with |
+| --- | --- | --- |
+| `[Business name]` | `index.html` — `<title>`, nav wordmark, footer | The trading name of the desk |
+| `[email]` | `index.html` — hero CTA `mailto:`, footer link text and `mailto:` | The desk's enquiry email address (appears in three places: two `mailto:` hrefs and the visible footer text) |
+| `[Your firm name]` | `index.html` — the `subject=` parameter of both `mailto:` links (URL-encoded as `%5BYour%20firm%20name%5D`) | Leave as a literal prompt for the sender, or drop it — it is the part of the email subject the referring firm fills in |
+| `[ABN]` | `index.html` — footer | The registered ABN |
+| `[Agent No. — placeholder until registration is finalised]` | `index.html` — FAQ answer "How do you lodge?" | The ASIC registered agent number, once registration is finalised |
+
+Also update:
+
+- `<meta name="description">` and `<title>` in `index.html` once the business
+  name is final.

--- a/corp-sec-desk/README.md
+++ b/corp-sec-desk/README.md
@@ -1,0 +1,89 @@
+# Corp-Sec Desk — one-page site
+
+Single-page static marketing site for a fixed-fee ASIC corporate secretarial
+desk serving small Australian accounting firms.
+
+- **Stack:** Vite + vanilla JS (ES modules), `three` and `gsap` (ScrollTrigger) via npm. No framework, no router, no backend, no analytics, no cookies.
+- **Signature element:** a three.js hero scene — ~120 translucent paper documents drifting in disarray that align into an ordered grid as you scroll ("chaos to order").
+- **Fonts:** Archivo (display), Public Sans (body), IBM Plex Mono (figures), self-hosted via `@fontsource`.
+
+## Before deploying
+
+Fill in every bracketed placeholder — see [`PLACEHOLDERS.md`](./PLACEHOLDERS.md).
+
+## Develop
+
+```sh
+npm install
+npm run dev
+```
+
+Open the printed local URL (defaults to `http://localhost:5173`).
+
+## Build
+
+```sh
+npm run build
+```
+
+The static output is written to `dist/`. Preview the production build locally:
+
+```sh
+npm run preview
+```
+
+## Deploy
+
+The build is fully static; any static host works.
+
+### Cloudflare Pages
+
+1. Push this directory to a Git repository and create a new Pages project
+   from it (Workers & Pages → Create → Pages → Connect to Git).
+2. Build settings:
+   - **Build command:** `npm run build`
+   - **Build output directory:** `dist`
+   - **Root directory:** path to this folder if it lives in a monorepo
+     (e.g. `corp-sec-desk`).
+3. Deploy. No environment variables are required.
+
+Or deploy directly from your machine:
+
+```sh
+npm run build
+npx wrangler pages deploy dist
+```
+
+### Netlify
+
+1. Create a new site from Git (Add new site → Import an existing project).
+2. Build settings:
+   - **Base directory:** this folder if it lives in a monorepo
+     (e.g. `corp-sec-desk`)
+   - **Build command:** `npm run build`
+   - **Publish directory:** `dist`
+3. Deploy. No environment variables are required.
+
+Or deploy directly from your machine:
+
+```sh
+npm run build
+npx netlify deploy --prod --dir=dist
+```
+
+## Accessibility and performance notes
+
+- Semantic HTML, a single `h1`, labelled landmarks, visible
+  `:focus-visible` states, AA contrast throughout.
+- Fully readable with JavaScript disabled: all content and the fee table are
+  plain HTML, the FAQ uses native `<details>` elements, and the hero falls
+  back to a static SVG of the ordered end-state.
+- `prefers-reduced-motion: reduce` disables all scroll animation
+  (via `gsap.matchMedia()`) and the three.js scene never initialises;
+  the static end-state is shown instead.
+- On small screens (`< 768px`) or low-memory devices
+  (`navigator.deviceMemory <= 4`) the scene runs with ~40 documents instead
+  of ~120.
+- The scene lazy-initialises after first paint, caps pixel ratio at 2,
+  enables antialiasing on desktop only, and pauses rendering when the tab is
+  hidden or the hero is out of the viewport.

--- a/corp-sec-desk/index.html
+++ b/corp-sec-desk/index.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>[Business name] — Fixed-fee ASIC corporate secretarial desk</title>
+  <meta name="description" content="A fixed-fee corporate secretarial desk for small Australian accounting firms. Standard ASIC company changes lodged within two business days of signed authority." />
+  <link rel="stylesheet" href="/src/styles.css" />
+  <script type="module" src="/src/main.js"></script>
+</head>
+<body>
+
+  <header class="site-header">
+    <nav class="nav container" aria-label="Primary">
+      <a class="wordmark" href="#top">[Business name]</a>
+      <ul class="nav-links" role="list">
+        <li><a href="#how-it-works">How it works</a></li>
+        <li><a href="#fees">Fees</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="top">
+
+    <!-- Hero -->
+    <section class="hero" aria-labelledby="hero-heading">
+      <div class="hero-scene" aria-hidden="true">
+        <div class="hero-static"></div>
+        <!-- canvas is injected here after first paint -->
+      </div>
+      <div class="hero-inner container">
+        <h1 id="hero-heading" class="hero-title">
+          <span class="hero-line">ASIC work off your plate.</span>
+          <span class="hero-line">Lodged in two business days.</span>
+        </h1>
+        <p class="hero-sub">A fixed-fee corporate secretarial desk for small accounting firms. No hourly billing, no backlog, no surprises.</p>
+        <div class="hero-cta">
+          <a class="btn btn-primary" href="mailto:[email]?subject=Corp-sec%20enquiry%20%E2%80%94%20%5BYour%20firm%20name%5D">Email the desk</a>
+          <a class="btn btn-secondary" href="#fees">See fees</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Sound familiar? -->
+    <section class="section section-paper familiar" aria-labelledby="familiar-heading" data-reveal>
+      <div class="container">
+        <h2 id="familiar-heading">Sound familiar?</h2>
+        <ul class="familiar-lines" role="list">
+          <li>484s queued behind chargeable work.</li>
+          <li>Annual reviews chasing signatures in week four.</li>
+          <li>Nobody actually owns the register.</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="section section-ink how" id="how-it-works" aria-labelledby="how-heading" data-reveal>
+      <div class="container">
+        <h2 id="how-heading">How it works</h2>
+        <ol class="steps">
+          <li><p><strong>Send the change.</strong> Email is fine.</p></li>
+          <li><p><strong>Documents prepared and e-signed</strong> — usually same day.</p></li>
+          <li><p><strong>Lodged with ASIC within two business days of signed authority.</strong> Confirmation lands in your inbox.</p></li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- Fees -->
+    <section class="section section-paper fees" id="fees" aria-labelledby="fees-heading" data-reveal>
+      <div class="container">
+        <h2 id="fees-heading">Fees</h2>
+        <table class="fee-table">
+          <caption class="visually-hidden">Fixed fees for corporate secretarial services</caption>
+          <thead class="visually-hidden">
+            <tr><th scope="col">Service</th><th scope="col">Fee</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Annual review pack <span class="fee-note">(per company, per year)</span></th>
+              <td class="fee-amount"><span class="fee-figure" data-count="450" data-prefix="$">$450</span></td>
+            </tr>
+            <tr>
+              <th scope="row">Standard company change <span class="fee-note">(Form 484)</span></th>
+              <td class="fee-amount"><span class="fee-figure" data-count="180" data-prefix="$">$180</span></td>
+            </tr>
+            <tr>
+              <th scope="row">Special resolutions / name change</th>
+              <td class="fee-amount"><span class="fee-figure" data-count="250" data-prefix="$">$250</span></td>
+            </tr>
+            <tr>
+              <th scope="row">New company incorporation</th>
+              <td class="fee-amount"><span class="fee-figure" data-count="300" data-prefix="$" data-suffix=" + ASIC fee">$300 + ASIC fee</span></td>
+            </tr>
+            <tr>
+              <th scope="row">Voluntary deregistration <span class="fee-note">(Form 6010)</span></th>
+              <td class="fee-amount"><span class="fee-figure" data-count="250" data-prefix="$" data-suffix=" + ASIC fee">$250 + ASIC fee</span></td>
+            </tr>
+            <tr>
+              <th scope="row">Registered agent transfer-in</th>
+              <td class="fee-amount"><span class="fee-figure">Free</span></td>
+            </tr>
+            <tr>
+              <th scope="row">Firm retainer <span class="fee-note">— your outsourced corp-sec desk</span></th>
+              <td class="fee-amount"><span class="fee-figure" data-count="300" data-prefix="from $" data-suffix="/mo">from $300/mo</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="fee-footnote">ASIC fees passed through at cost. Invoiced after lodgement, 7-day terms.</p>
+      </div>
+    </section>
+
+    <!-- Lane discipline strip -->
+    <section class="section-strip section-ink" aria-label="Lane discipline" data-reveal>
+      <div class="container">
+        <p class="strip-line">Corp-sec only. No tax, no BAS, no advisory. Your client relationships stay yours.</p>
+      </div>
+    </section>
+
+    <!-- Capacity -->
+    <section class="section section-paper capacity" aria-labelledby="capacity-heading" data-reveal>
+      <div class="container">
+        <h2 id="capacity-heading">Five retainer desks. That&rsquo;s the cap.</h2>
+        <p class="capacity-sub">The two-day promise matters more than growth. When the desks are full, there&rsquo;s a waitlist.</p>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="section section-ink faq" aria-labelledby="faq-heading" data-reveal>
+      <div class="container">
+        <h2 id="faq-heading">Questions</h2>
+        <div class="accordion">
+          <details class="accordion-item">
+            <summary>How do you lodge?</summary>
+            <div class="accordion-body">
+              <p>As a registered ASIC agent <span class="mono">[Agent No. — placeholder until registration is finalised]</span>.</p>
+            </div>
+          </details>
+          <details class="accordion-item">
+            <summary>What does &ldquo;two business days&rdquo; mean?</summary>
+            <div class="accordion-body">
+              <p>Measured from receipt of signed authority and any required corporate key — not from first email.</p>
+            </div>
+          </details>
+          <details class="accordion-item">
+            <summary>What does the retainer cover?</summary>
+            <div class="accordion-body">
+              <p>An agreed company count, unlimited standard changes, annual review management, and priority turnaround.</p>
+            </div>
+          </details>
+          <details class="accordion-item">
+            <summary>How is client data handled?</summary>
+            <div class="accordion-body">
+              <p>Australian-hosted storage, multi-factor authentication on every system, least-access handling. Documents are processed locally wherever possible.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer" id="contact">
+    <div class="container">
+      <p>
+        [Business name] · ABN <span class="mono">[ABN]</span> ·
+        <a href="mailto:[email]?subject=Corp-sec%20enquiry%20%E2%80%94%20%5BYour%20firm%20name%5D">[email]</a> ·
+        Based in Macarthur, NSW. Serving firms Australia-wide.
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/corp-sec-desk/package-lock.json
+++ b/corp-sec-desk/package-lock.json
@@ -1,0 +1,871 @@
+{
+  "name": "corp-sec-desk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "corp-sec-desk",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@fontsource/archivo": "^5.2.8",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/public-sans": "^5.2.7",
+        "gsap": "^3.15.0",
+        "three": "^0.184.0",
+        "vite": "^8.0.16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fontsource/archivo": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/archivo/-/archivo-5.2.8.tgz",
+      "integrity": "sha512-Fc4yuMt85MmcYooUVpYHAJRJTymPv2+J9HsMP2f5mxR/0pIWgE2V5XfgNTavPpklX2rJFprdT36iE6Rr8ds9MA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/public-sans": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/public-sans/-/public-sans-5.2.7.tgz",
+      "integrity": "sha512-pVttDr3HvhVIt2x6sZJfZKksNEpq23C1JCHTQwT9KWJdmFRdNeRM8gQftq8uP72sPW+p3Ku9x8HPk2E392DFvg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gsap": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
+      "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/corp-sec-desk/package.json
+++ b/corp-sec-desk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "corp-sec-desk",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Single-page static marketing site for a fixed-fee ASIC corporate secretarial desk.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@fontsource/archivo": "^5.2.8",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/public-sans": "^5.2.7",
+    "gsap": "^3.15.0",
+    "three": "^0.184.0"
+  },
+  "devDependencies": {
+    "vite": "^8.0.16"
+  }
+}

--- a/corp-sec-desk/public/hero-static.svg
+++ b/corp-sec-desk/public/hero-static.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+<rect width="1600" height="900" fill="#11181A"/>
+<rect x="94.1" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.134" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="217.2" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.077"/>
+<rect x="340.2" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.103"/>
+<rect x="463.3" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.120"/>
+<rect x="586.4" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.103"/>
+<rect x="709.5" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.111"/>
+<rect x="832.5" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.079"/>
+<rect x="955.6" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.117"/>
+<rect x="1078.7" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.064"/>
+<rect x="1201.8" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.097"/>
+<rect x="1324.8" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.125"/>
+<rect x="1447.9" y="62.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.101"/>
+<rect x="94.1" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.115"/>
+<rect x="217.2" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.106"/>
+<rect x="340.2" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.133"/>
+<rect x="463.3" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.087"/>
+<rect x="586.4" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.087"/>
+<rect x="709.5" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.084"/>
+<rect x="832.5" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.084"/>
+<rect x="955.6" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.105"/>
+<rect x="1078.7" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.130"/>
+<rect x="1201.8" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.082" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="1324.8" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.101"/>
+<rect x="1447.9" y="162.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.075"/>
+<rect x="94.1" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.064"/>
+<rect x="217.2" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.088"/>
+<rect x="340.2" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.134"/>
+<rect x="463.3" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.073"/>
+<rect x="586.4" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.083"/>
+<rect x="709.5" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.094"/>
+<rect x="832.5" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.103"/>
+<rect x="955.6" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.079"/>
+<rect x="1078.7" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.097"/>
+<rect x="1201.8" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.111"/>
+<rect x="1324.8" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.101"/>
+<rect x="1447.9" y="262.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.115"/>
+<rect x="94.1" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.092"/>
+<rect x="217.2" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.080"/>
+<rect x="340.2" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.088"/>
+<rect x="463.3" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.091"/>
+<rect x="586.4" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.130"/>
+<rect x="709.5" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.126"/>
+<rect x="832.5" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.093" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="955.6" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.066"/>
+<rect x="1078.7" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.078"/>
+<rect x="1201.8" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.072"/>
+<rect x="1324.8" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.107"/>
+<rect x="1447.9" y="362.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.134"/>
+<rect x="94.1" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.131"/>
+<rect x="217.2" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.133"/>
+<rect x="340.2" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.082"/>
+<rect x="463.3" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.080" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="586.4" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.060" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="709.5" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.079"/>
+<rect x="832.5" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.099"/>
+<rect x="955.6" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.079"/>
+<rect x="1078.7" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.079"/>
+<rect x="1201.8" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.132"/>
+<rect x="1324.8" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.099"/>
+<rect x="1447.9" y="462.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.133" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="94.1" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.134"/>
+<rect x="217.2" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.132" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="340.2" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.137"/>
+<rect x="463.3" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.114"/>
+<rect x="586.4" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.078"/>
+<rect x="709.5" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.105"/>
+<rect x="832.5" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.122" stroke="#2E6B4E" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="955.6" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.117"/>
+<rect x="1078.7" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.063"/>
+<rect x="1201.8" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.134"/>
+<rect x="1324.8" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.115"/>
+<rect x="1447.9" y="562.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.063"/>
+<rect x="94.1" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.129"/>
+<rect x="217.2" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.136"/>
+<rect x="340.2" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.094"/>
+<rect x="463.3" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.118"/>
+<rect x="586.4" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.092"/>
+<rect x="709.5" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.092"/>
+<rect x="832.5" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.105"/>
+<rect x="955.6" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.110"/>
+<rect x="1078.7" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.087"/>
+<rect x="1201.8" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.094"/>
+<rect x="1324.8" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.085"/>
+<rect x="1447.9" y="662.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.140"/>
+<rect x="94.1" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.130"/>
+<rect x="217.2" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.076"/>
+<rect x="340.2" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.071"/>
+<rect x="463.3" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.105"/>
+<rect x="586.4" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.136"/>
+<rect x="709.5" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.075"/>
+<rect x="832.5" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.073"/>
+<rect x="955.6" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.102"/>
+<rect x="1078.7" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.101"/>
+<rect x="1201.8" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.089"/>
+<rect x="1324.8" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.062"/>
+<rect x="1447.9" y="762.0" width="58" height="76" fill="#F2EFE7" fill-opacity="0.103"/>
+</svg>

--- a/corp-sec-desk/src/accordion.js
+++ b/corp-sec-desk/src/accordion.js
@@ -1,0 +1,15 @@
+/* FAQ accordion. Built on <details>/<summary>, so it is fully readable
+   with JavaScript disabled and keyboard operable natively (Tab to focus,
+   Enter/Space to toggle). This enhancement just keeps one item open at
+   a time. */
+export function initAccordion() {
+  const items = document.querySelectorAll(".accordion-item");
+  items.forEach((item) => {
+    item.addEventListener("toggle", () => {
+      if (!item.open) return;
+      items.forEach((other) => {
+        if (other !== item) other.open = false;
+      });
+    });
+  });
+}

--- a/corp-sec-desk/src/main.js
+++ b/corp-sec-desk/src/main.js
@@ -1,0 +1,34 @@
+import { initMotion } from "./motion.js";
+import { initAccordion } from "./accordion.js";
+
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+initMotion();
+initAccordion();
+
+// Lazy-init the three.js hero scene after first paint. The hero headline,
+// CTA, and the static SVG end-state are all present and readable before
+// (and without) this running.
+if (!reducedMotion.matches) {
+  const start = () => {
+    import("./scene.js").then(({ initScene }) => {
+      const container = document.querySelector(".hero-scene");
+      if (!container) return;
+      const small =
+        window.matchMedia("(max-width: 767px)").matches ||
+        (navigator.deviceMemory !== undefined && navigator.deviceMemory <= 4);
+      initScene(container, { count: small ? 40 : 120 });
+    });
+  };
+  // Two rAFs guarantee we are past the first paint; idle callback keeps the
+  // main thread clear for LCP.
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      if ("requestIdleCallback" in window) {
+        requestIdleCallback(start, { timeout: 1500 });
+      } else {
+        setTimeout(start, 200);
+      }
+    })
+  );
+}

--- a/corp-sec-desk/src/motion.js
+++ b/corp-sec-desk/src/motion.js
@@ -1,0 +1,87 @@
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function initMotion() {
+  const mm = gsap.matchMedia();
+
+  mm.add("(prefers-reduced-motion: no-preference)", () => {
+    heroIntro();
+    sectionReveals();
+    feeCounters();
+  });
+}
+
+/* Hero headline lines stagger in once on load: y 24px, opacity,
+   0.08s stagger, well under 0.9s total. */
+function heroIntro() {
+  gsap.from(".hero-line", {
+    y: 24,
+    autoAlpha: 0,
+    duration: 0.6,
+    stagger: 0.08,
+    ease: "power2.out",
+  });
+  gsap.from(".hero-sub, .hero-cta", {
+    y: 24,
+    autoAlpha: 0,
+    duration: 0.6,
+    delay: 0.16,
+    stagger: 0.08,
+    ease: "power2.out",
+  });
+}
+
+/* One fade-up reveal per section. */
+function sectionReveals() {
+  document.querySelectorAll("[data-reveal]").forEach((section) => {
+    gsap.from(section.querySelector(".container"), {
+      y: 28,
+      autoAlpha: 0,
+      duration: 0.7,
+      ease: "power2.out",
+      scrollTrigger: {
+        trigger: section,
+        start: "top 82%",
+        once: true,
+      },
+    });
+  });
+}
+
+/* Fee amounts count up once when the table enters the viewport.
+   Final values are already in the markup (no-JS safe); widths are locked
+   before animating so there is zero layout shift. */
+function feeCounters() {
+  const figures = document.querySelectorAll(".fee-figure[data-count]");
+  if (!figures.length) return;
+
+  figures.forEach((el) => {
+    el.style.display = "inline-block";
+    el.style.minWidth = `${Math.ceil(el.getBoundingClientRect().width)}px`;
+    el.style.textAlign = "right";
+  });
+
+  ScrollTrigger.create({
+    trigger: ".fee-table",
+    start: "top 80%",
+    once: true,
+    onEnter: () => {
+      figures.forEach((el) => {
+        const target = parseInt(el.dataset.count, 10);
+        const prefix = el.dataset.prefix || "";
+        const suffix = el.dataset.suffix || "";
+        const state = { value: 0 };
+        gsap.to(state, {
+          value: target,
+          duration: 1.1,
+          ease: "power1.out",
+          onUpdate: () => {
+            el.textContent = `${prefix}${Math.round(state.value)}${suffix}`;
+          },
+        });
+      });
+    },
+  });
+}

--- a/corp-sec-desk/src/scene.js
+++ b/corp-sec-desk/src/scene.js
@@ -1,0 +1,233 @@
+/* "Chaos to order" — the signature hero scene.
+   A field of thin translucent paper-toned rectangles drifting in disarray;
+   on scroll they tween into a neat aligned grid. One GSAP timeline,
+   scrubbed by ScrollTrigger (scrub: 0.8), interpolates every document
+   from its scattered transform to its grid slot. */
+import {
+  Color,
+  EdgesGeometry,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Mesh,
+  MeshBasicMaterial,
+  PerspectiveCamera,
+  PlaneGeometry,
+  Scene,
+  WebGLRenderer,
+} from "three";
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+gsap.registerPlugin(ScrollTrigger);
+
+const INK = 0x11181a;
+const PAPER = 0xf2efe7;
+const LEDGER_GREEN = 0x2e6b4e;
+
+const DOC_W = 0.55;
+const DOC_H = 0.72;
+const CAMERA_Z = 14;
+const FOV = 35;
+
+// Deterministic PRNG so the scatter looks considered, not random per load.
+function mulberry32(seed) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function initScene(container, { count = 120 } = {}) {
+  const isDesktop = window.matchMedia("(min-width: 768px)").matches;
+
+  const renderer = new WebGLRenderer({
+    antialias: isDesktop,
+    alpha: false,
+    powerPreference: "low-power",
+  });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setClearColor(INK, 1);
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  const scene = new Scene();
+  scene.background = new Color(INK);
+
+  const camera = new PerspectiveCamera(
+    FOV,
+    container.clientWidth / container.clientHeight,
+    0.1,
+    50
+  );
+  camera.position.z = CAMERA_Z;
+
+  // World-space size of the viewport at z = 0.
+  const viewSize = () => {
+    const h = 2 * CAMERA_Z * Math.tan((FOV * Math.PI) / 360);
+    return { w: h * camera.aspect, h };
+  };
+
+  const rand = mulberry32(20260612);
+  const geometry = new PlaneGeometry(DOC_W, DOC_H);
+  const edgeGeometry = new EdgesGeometry(geometry);
+  const group = new Group();
+  scene.add(group);
+
+  const docs = [];
+  const { w: vw, h: vh } = viewSize();
+
+  // Grid layout: roughly viewport-shaped.
+  const cols = Math.round(Math.sqrt((count * vw) / vh));
+  const rows = Math.ceil(count / cols);
+  const gridW = vw * 0.86;
+  const gridH = vh * 0.82;
+
+  for (let i = 0; i < count; i++) {
+    const tone = 0.05 + rand() * 0.1;
+    const material = new MeshBasicMaterial({
+      color: PAPER,
+      transparent: true,
+      opacity: tone,
+      depthWrite: false,
+    });
+    const mesh = new Mesh(geometry, material);
+
+    // A few documents carry ledger-green edges; the rest stay plain.
+    if (rand() < 0.09) {
+      const edges = new LineSegments(
+        edgeGeometry,
+        new LineBasicMaterial({
+          color: LEDGER_GREEN,
+          transparent: true,
+          opacity: 0.6,
+        })
+      );
+      mesh.add(edges);
+    }
+
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const doc = {
+      mesh,
+      scatter: {
+        x: (rand() - 0.5) * vw * 1.15,
+        y: (rand() - 0.5) * vh * 1.15,
+        z: (rand() - 0.5) * 4,
+        rx: (rand() - 0.5) * 0.7,
+        ry: (rand() - 0.5) * 0.7,
+        rz: (rand() - 0.5) * 0.9,
+      },
+      slot: {
+        x: cols > 1 ? (col / (cols - 1) - 0.5) * gridW : 0,
+        y: rows > 1 ? (0.5 - row / (rows - 1)) * gridH : 0,
+        z: 0,
+      },
+      // Slow noise-based idle drift, rotation kept ≤ 0.15 rad.
+      drift: {
+        phase: rand() * Math.PI * 2,
+        speed: 0.12 + rand() * 0.18,
+        amp: 0.18 + rand() * 0.3,
+        rot: 0.06 + rand() * 0.08,
+      },
+      // Small per-document offset so alignment cascades, not snaps.
+      delay: rand() * 0.25,
+    };
+    group.add(mesh);
+    docs.push(doc);
+  }
+
+  // Single scrub-driven progress value: 0 = scattered, 1 = ordered grid.
+  const progress = { t: 0 };
+  const timeline = gsap.timeline({
+    scrollTrigger: {
+      trigger: ".hero",
+      start: "top top",
+      end: "bottom 25%",
+      scrub: 0.8,
+    },
+  });
+  timeline.to(progress, { t: 1, ease: "none" });
+
+  const smooth = (x) => x * x * (3 - 2 * x);
+
+  function update(timeSec) {
+    for (const doc of docs) {
+      const { mesh, scatter, slot, drift, delay } = doc;
+      const local = Math.min(
+        Math.max((progress.t - delay) / (1 - delay), 0),
+        1
+      );
+      const t = smooth(local);
+      const idle = 1 - t;
+
+      const p = drift.phase + timeSec * drift.speed;
+      const dx = Math.sin(p) * drift.amp * idle;
+      const dy = Math.cos(p * 0.83 + 1.7) * drift.amp * 0.7 * idle;
+      const dr = Math.sin(p * 0.61) * drift.rot * idle;
+
+      mesh.position.set(
+        scatter.x + (slot.x - scatter.x) * t + dx,
+        scatter.y + (slot.y - scatter.y) * t + dy,
+        scatter.z + (slot.z - scatter.z) * t
+      );
+      mesh.rotation.set(
+        scatter.rx * idle + dr,
+        scatter.ry * idle + dr * 0.6,
+        scatter.rz * idle + dr * 0.4
+      );
+    }
+    renderer.render(scene, camera);
+  }
+
+  // Render loop: paused when the tab is hidden or the hero leaves the
+  // viewport.
+  let rafId = null;
+  let inView = true;
+
+  function loop(timeMs) {
+    rafId = null;
+    update(timeMs / 1000);
+    schedule();
+  }
+
+  function schedule() {
+    if (rafId === null && inView && !document.hidden) {
+      rafId = requestAnimationFrame(loop);
+    }
+  }
+
+  function halt() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
+  const observer = new IntersectionObserver(([entry]) => {
+    inView = entry.isIntersecting;
+    if (inView) schedule();
+    else halt();
+  });
+  observer.observe(container);
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) halt();
+    else schedule();
+  });
+
+  window.addEventListener("resize", () => {
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+  });
+
+  // The canvas now owns the background; drop the static fallback layer.
+  const staticLayer = container.querySelector(".hero-static");
+  if (staticLayer) staticLayer.style.display = "none";
+
+  schedule();
+}

--- a/corp-sec-desk/src/styles.css
+++ b/corp-sec-desk/src/styles.css
@@ -1,0 +1,526 @@
+/* ------------------------------------------------------------------
+   Fonts (self-hosted via @fontsource, font-display: swap)
+   ------------------------------------------------------------------ */
+@import "@fontsource/archivo/latin-600.css";
+@import "@fontsource/archivo/latin-700.css";
+@import "@fontsource/public-sans/latin-400.css";
+@import "@fontsource/public-sans/latin-500.css";
+@import "@fontsource/ibm-plex-mono/latin-500.css";
+
+/* ------------------------------------------------------------------
+   Design tokens
+   ------------------------------------------------------------------ */
+:root {
+  --ink: #11181a;
+  --paper: #f2efe7;
+  --ledger-green: #2e6b4e;
+  --rule: #c9c4b8;
+  --slate: #5c6b66;
+
+  --font-display: "Archivo", system-ui, sans-serif;
+  --font-body: "Public Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  --container: 1100px;
+  --space-1: 0.5rem;
+  --space-2: 1rem;
+  --space-3: 1.5rem;
+  --space-4: 2.5rem;
+  --space-5: 4rem;
+  --space-6: 6.5rem;
+
+  /* Type scale */
+  --text-sm: 0.875rem;
+  --text-base: 1.0625rem;
+  --text-lg: 1.25rem;
+  --text-xl: clamp(1.5rem, 1.2rem + 1.4vw, 2.125rem);
+  --text-2xl: clamp(1.875rem, 1.4rem + 2.2vw, 2.75rem);
+  --text-hero: clamp(2.25rem, 1.5rem + 4vw, 4.25rem);
+}
+
+/* ------------------------------------------------------------------
+   Base
+   ------------------------------------------------------------------ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: var(--text-base);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-stretch: 103%;
+  letter-spacing: -0.015em;
+  line-height: 1.12;
+  margin: 0 0 var(--space-3);
+}
+
+p {
+  margin: 0 0 var(--space-2);
+}
+
+a {
+  color: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid var(--ledger-green);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.section-ink :focus-visible,
+.site-header :focus-visible,
+.hero :focus-visible,
+.site-footer :focus-visible {
+  outline-color: var(--paper);
+}
+
+.container {
+  max-width: var(--container);
+  margin-inline: auto;
+  padding-inline: clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ------------------------------------------------------------------
+   Header / nav
+   ------------------------------------------------------------------ */
+.site-header {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 10;
+  border-bottom: 1px solid rgb(242 239 231 / 0.16);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding-block: var(--space-2);
+}
+
+.wordmark {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: var(--text-lg);
+  letter-spacing: -0.01em;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  gap: clamp(1rem, 3vw, 2.25rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  text-decoration: none;
+  font-weight: 500;
+  font-size: var(--text-sm);
+}
+
+.nav-links a:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.3em;
+}
+
+/* ------------------------------------------------------------------
+   Hero
+   ------------------------------------------------------------------ */
+.hero {
+  position: relative;
+  min-height: 100svh;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+.hero-scene {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.hero-scene canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* Static fallback: ordered end-state, shown when the scene is not running
+   (no JS, reduced motion, or before lazy init). */
+.hero-static {
+  position: absolute;
+  inset: 0;
+  background-image: url("/hero-static.svg");
+  background-size: cover;
+  background-position: center;
+  opacity: 0.9;
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding-block: var(--space-6);
+}
+
+.hero-title {
+  font-size: var(--text-hero);
+  max-width: 26ch;
+  margin-bottom: var(--space-3);
+}
+
+.hero-line {
+  display: block;
+}
+
+.hero-sub {
+  max-width: 44ch;
+  font-size: var(--text-lg);
+  color: rgb(242 239 231 / 0.82);
+  margin-bottom: var(--space-4);
+}
+
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.8em 1.6em;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-base);
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+}
+
+.btn-primary {
+  background: var(--ledger-green);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #25593f;
+}
+
+.btn-secondary {
+  border-color: rgb(242 239 231 / 0.45);
+  color: var(--paper);
+}
+
+.btn-secondary:hover {
+  border-color: var(--paper);
+}
+
+/* ------------------------------------------------------------------
+   Sections
+   ------------------------------------------------------------------ */
+.section {
+  padding-block: var(--space-6);
+}
+
+.section-paper {
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.section-paper h2 {
+  color: var(--ink);
+}
+
+.section-ink {
+  background: var(--ink);
+  color: var(--paper);
+  border-block: 1px solid rgb(242 239 231 / 0.12);
+}
+
+.section-paper + .section-paper {
+  border-top: 1px solid var(--rule);
+}
+
+.section h2 {
+  font-size: var(--text-2xl);
+}
+
+/* Sound familiar? */
+.familiar-lines {
+  list-style: none;
+  margin: var(--space-4) 0 0;
+  padding: 0;
+}
+
+.familiar-lines li {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-xl);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  padding-block: var(--space-3);
+  border-top: 1px solid var(--rule);
+}
+
+.familiar-lines li:last-child {
+  border-bottom: 1px solid var(--rule);
+}
+
+/* How it works */
+.steps {
+  list-style: none;
+  counter-reset: step;
+  margin: var(--space-4) 0 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.steps li {
+  counter-increment: step;
+  border-top: 1px solid rgb(242 239 231 / 0.25);
+  padding-top: var(--space-3);
+}
+
+.steps li::before {
+  content: counter(step, decimal-leading-zero);
+  display: block;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--ledger-green);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-2);
+}
+
+.section-ink .steps li::before {
+  color: #6fae8f; /* ledger-green lifted for AA contrast on ink */
+}
+
+.steps p {
+  margin: 0;
+  color: rgb(242 239 231 / 0.78);
+}
+
+.steps strong {
+  display: block;
+  color: var(--paper);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-lg);
+  line-height: 1.3;
+  margin-bottom: var(--space-1);
+}
+
+/* Fees — the centrepiece */
+.fee-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--space-4);
+  font-size: var(--text-base);
+}
+
+.fee-table th[scope="row"] {
+  text-align: left;
+  font-weight: 500;
+  padding: var(--space-3) var(--space-2) var(--space-3) 0;
+  border-top: 1px solid var(--rule);
+}
+
+.fee-table td {
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--rule);
+}
+
+.fee-table tbody tr:last-child th,
+.fee-table tbody tr:last-child td {
+  border-bottom: 1px solid var(--rule);
+}
+
+.fee-note {
+  color: var(--slate);
+  font-weight: 400;
+}
+
+.fee-amount {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.fee-figure {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-lg);
+  color: var(--ledger-green);
+}
+
+.fee-footnote {
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--slate);
+}
+
+/* Lane discipline strip */
+.section-strip {
+  padding-block: var(--space-4);
+}
+
+.strip-line {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-xl);
+  letter-spacing: -0.01em;
+  text-align: center;
+  text-wrap: balance;
+}
+
+/* Capacity */
+.capacity h2 {
+  margin-bottom: var(--space-2);
+}
+
+.capacity-sub {
+  max-width: 52ch;
+  color: var(--slate);
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+/* FAQ accordion */
+.accordion {
+  margin-top: var(--space-4);
+  border-top: 1px solid rgb(242 239 231 / 0.25);
+}
+
+.accordion-item {
+  border-bottom: 1px solid rgb(242 239 231 / 0.25);
+}
+
+.accordion-item summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding-block: var(--space-3);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-lg);
+}
+
+.accordion-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-item summary::after {
+  content: "+";
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: #6fae8f;
+  flex: none;
+}
+
+.accordion-item[open] summary::after {
+  content: "\2212"; /* minus */
+}
+
+.accordion-body {
+  padding-bottom: var(--space-3);
+  max-width: 62ch;
+  color: rgb(242 239 231 / 0.82);
+}
+
+.accordion-body p {
+  margin: 0;
+}
+
+/* ------------------------------------------------------------------
+   Footer
+   ------------------------------------------------------------------ */
+.site-footer {
+  padding-block: var(--space-5);
+  border-top: 1px solid rgb(242 239 231 / 0.12);
+  font-size: var(--text-sm);
+  color: rgb(242 239 231 / 0.7);
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+.site-footer a {
+  color: var(--paper);
+}
+
+/* ------------------------------------------------------------------
+   Responsive
+   ------------------------------------------------------------------ */
+@media (max-width: 767px) {
+  .steps {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+
+  .section {
+    padding-block: var(--space-5);
+  }
+
+  .fee-table th[scope="row"] {
+    padding-right: var(--space-1);
+  }
+}
+
+/* ------------------------------------------------------------------
+   Reduced motion
+   ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
Single-page static marketing site for a fixed-fee ASIC corporate secretarial desk, built to spec and living in its own `corp-sec-desk/` folder.

## Stack
- Vite + vanilla JS (ES modules), no framework/router
- `three` and `gsap` (ScrollTrigger) via npm
- Static `dist/` output — deployable to Cloudflare Pages or Netlify
- No backend, analytics, or cookies; primary CTA is a `mailto:`

## Highlights
- **"Chaos to order" hero**: ~120 translucent paper documents drift in disarray, then align into a grid on scroll (one GSAP timeline, `scrub: 0.8`). Lazy-inits after first paint; render loop pauses when the tab is hidden or the hero is off-screen; pixel ratio capped at 2. Drops to ~40 documents on mobile/low-memory; never initialises under `prefers-reduced-motion` (static SVG end-state shown instead).
- **GSAP elsewhere**: hero headline stagger on load, one fade-up reveal per section, fee amounts count up once with widths locked (zero layout shift).
- **Design tokens** applied verbatim: ink/paper/ledger-green/rule/slate palette; Archivo, Public Sans, IBM Plex Mono self-hosted via `@fontsource`. 1100px column, hairline rules, fee table as centrepiece.
- **Accessibility/quality floor**: semantic HTML, single `h1`, labelled landmarks, visible `:focus-visible` states, AA contrast. Fully readable with JavaScript disabled — content, fee table, native `<details>` FAQ, and a static ordered-grid hero all work.

## Deliverables
- `README.md` — build and Cloudflare Pages / Netlify deploy steps
- `PLACEHOLDERS.md` — every bracketed value to fill before deploy (business name, email, ABN, ASIC agent number)

## Verification
Production build run and opened headlessly with **zero console errors**. Confirmed: hero scatter, mid-scroll alignment, fee count-up, the no-JS fallback render, and that `prefers-reduced-motion` skips the canvas entirely. Initial payload (~48KB gzip JS+CSS) is well under the 600KB budget; the three.js scene loads as a separate lazy chunk.

https://claude.ai/code/session_01Na5SVjo28LgYzxcdTcR5ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na5SVjo28LgYzxcdTcR5ry)_