### PR TITLE
Add GitHub Pages deploy workflow for corp-sec-desk

### DIFF
--- a/.github/workflows/deploy-corp-sec-desk.yml
+++ b/.github/workflows/deploy-corp-sec-desk.yml
@@ -1,0 +1,51 @@
+name: Deploy corp-sec-desk to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "corp-sec-desk/**"
+      - ".github/workflows/deploy-corp-sec-desk.yml"
+  workflow_dispatch:
+
+# Allow one concurrent deployment; let in-progress runs finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: corp-sec-desk
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: corp-sec-desk/package-lock.json
+      - run: npm ci
+      - run: npm run build
+        env:
+          # Serve assets from the project-pages sub-path.
+          BASE_PATH: /${{ github.event.repository.name }}/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: corp-sec-desk/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/corp-sec-desk/vite.config.js
+++ b/corp-sec-desk/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+
+// Project lives at https://<user>.github.io/MyPortfolio/ on GitHub Pages,
+// so assets are served from the /MyPortfolio/ sub-path. The BASE_PATH env
+// var lets the GitHub Actions workflow override this; it defaults to "/"
+// for local dev and root-domain hosts (Cloudflare Pages, Netlify).
+export default defineConfig({
+  base: process.env.BASE_PATH || "/",
+});


### PR DESCRIPTION
Follow-up to #4. The deploy workflow commit landed on the branch after #4 was merged at the site commit, so `master` currently has the site but no Pages workflow. This lands it.

## Changes
- **`.github/workflows/deploy-corp-sec-desk.yml`** — builds `corp-sec-desk/` and deploys `dist/` to GitHub Pages on push to `master` (when `corp-sec-desk/**` changes) and via manual dispatch.
- **`corp-sec-desk/vite.config.js`** — configurable `base` via `BASE_PATH` env (defaults to `/` for local dev and root-domain hosts; CI sets it to the repo sub-path so project-pages asset URLs resolve).

## After merging — one manual step
Enable Pages: **Settings → Pages → Build and deployment → Source: GitHub Actions**. Then the site publishes to `https://jordansosa.github.io/MyPortfolio/`.

Verified the sub-path build locally: `index.html`, fonts, and `hero-static.svg` all rebase correctly under `/MyPortfolio/`.

https://claude.ai/code/session_01Na5SVjo28LgYzxcdTcR5ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na5SVjo28LgYzxcdTcR5ry)_